### PR TITLE
Create wpa_supplicant.conf

### DIFF
--- a/wpa_supplicant.conf
+++ b/wpa_supplicant.conf
@@ -1,0 +1,17 @@
+country=FR
+ctrl_interfacce=DIR=/var/run/wpa_supplicant GROUP=netdev
+update_config=1
+
+network={
+  ssid="wifi-name"
+  proto=RSN
+  key-mgmt=WPA-EAP
+  pairwise=CCMP
+  group=CCMP
+  auth_aln=OPEN
+  eap=PEAP
+  identity="DOMAIN\myusername"
+  password="mypassword"
+  phase1="peapver=0"
+  phase2="auth=MSCHAPV2"
+}


### PR DESCRIPTION
configuration pour l'authentification wifi à mettre dans /etc/wpa_supplicant/wpa_supplicant.conf
attention à saisir le bon usert et password ainsi que le bon SSID wifi.